### PR TITLE
Add network diagram and fix API metrics port in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ book-share-monitoring provides monitoring, alerting, and observability for the B
 The monitoring stack runs via Docker Compose on the external `booksharing` network (shared with the services being monitored).
 
 **Prometheus** (`prom/prometheus:v2.53.0`) — scrapes metrics from services by container name:
-- `booksharing-api:8080/metrics` (book-share-api, 10s interval)
+- `booksharing-api:8081/metrics` (book-share-api, 10s interval)
 - `cover-detection:8000/metrics` (cover-detection, 15s interval)
 
 **Grafana** (`grafana/grafana:11.1.0`) — dashboards and visualization, exposed on port 3100. Datasource and dashboard provisioning are file-based under `grafana/provisioning/`.
@@ -32,6 +32,8 @@ The monitoring stack runs via Docker Compose on the external `booksharing` netwo
 **Loki** (`grafana/loki:3.6.0`) — log aggregation and storage. Not exposed to the host; only reachable on the internal `monitoring-internal` Docker network by Grafana and Alloy. Stores logs on the local filesystem with 7-day retention.
 
 **Alloy** (`grafana/alloy:v1.14.1`) — log collector that discovers Docker containers via the Docker socket and forwards their logs to Loki. Replaces the now-EOL Promtail. Runs as root (required for Docker socket access).
+
+For a full diagram of containers, networks, and ports see `docs/network-diagram.md`.
 
 ### File Structure
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ This repository provides monitoring, alerting, and observability tooling for the
 | book-share-api | ASP.NET Core 8.0, PostgreSQL 15, SignalR | REST API (auth, books, shares, chat, notifications, communities) |
 | book-share-cover-detection | Python, Florence-2, GLiNER | `POST /analyze`, `GET /health` |
 
+## Network Architecture
+
+See [`docs/network-diagram.md`](docs/network-diagram.md) for a diagram of how containers, networks, and ports are connected.
+
 ## Stack
 
 | Component | Image | Purpose |

--- a/docs/network-diagram.md
+++ b/docs/network-diagram.md
@@ -1,0 +1,53 @@
+# Network Diagram
+
+```mermaid
+flowchart TB
+    user(["User Browser"])
+
+    subgraph booksharing["booksharing (external)"]
+        direction TB
+        api["booksharing-api"]
+        cover["cover-detection"]
+        prometheus["bookshare-prometheus"]
+    end
+
+    grafana["bookshare-grafana"]
+
+    subgraph monitoring_internal["monitoring-internal (internal)"]
+        direction TB
+        loki["bookshare-loki"]
+        alloy["bookshare-alloy"]
+    end
+
+    dockersock[("Docker socket (host)")]
+
+    user -->|"port 3100"| grafana
+    grafana -->|"PromQL"| prometheus
+    grafana -->|"LogQL"| loki
+    prometheus -->|"scrape every 10s"| api
+    prometheus -->|"scrape every 15s"| cover
+    alloy -->|"push logs"| loki
+    alloy -.->|"log discovery"| dockersock
+```
+
+## Networks
+
+| Network | Type | Members |
+|---|---|---|
+| `booksharing` | external (shared) | `booksharing-api`, `cover-detection`, `bookshare-prometheus`, `bookshare-grafana` |
+| `monitoring-internal` | internal (no internet routing) | `bookshare-grafana`, `bookshare-loki`, `bookshare-alloy` |
+
+Grafana sits on both networks so it can query Prometheus (over `booksharing`) and Loki (over `monitoring-internal`).
+
+## Host Port Exposure
+
+| Container | Host Binding | Notes |
+|---|---|---|
+| `bookshare-grafana` | `0.0.0.0:3100` | Accessible externally |
+| `bookshare-prometheus` | `127.0.0.1:9090` | Localhost only |
+| `bookshare-alloy` | `127.0.0.1:12345` | UI only; not a published Docker port (`--server.http.listen-addr`) |
+| `bookshare-loki` | — | No host exposure; reachable only on `monitoring-internal` |
+
+## Log Collection
+
+Alloy collects logs by reading `/var/run/docker.sock` directly (not via any Docker network). It discovers all containers on the host, labels them by container name, and pushes their logs to Loki over `monitoring-internal`. Alloy runs as root because Docker socket access requires it.


### PR DESCRIPTION
## Summary

- Adds `docs/network-diagram.md` with a Mermaid diagram documenting container topology, Docker networks (`booksharing` and `monitoring-internal`), host port exposure, and data flows between services
- Links to the diagram from both `README.md` and `CLAUDE.md`
- Fixes a port mismatch in `CLAUDE.md`: the book-share-api exposes metrics on `:8081` (its internal monitoring port) not `:8080` (the public API port) — confirmed against the API's `docker-compose.yml` and `Program.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)