### PR TITLE
Add cover-detection structured logging and stage latency dashboard support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ The monitoring stack runs via Docker Compose on the external `booksharing` netwo
 
 **Loki** (`grafana/loki:3.6.0`) — log aggregation and storage. Not exposed to the host; only reachable on the internal `monitoring-internal` Docker network by Grafana and Alloy. Stores logs on the local filesystem with 7-day retention.
 
-**Alloy** (`grafana/alloy:v1.14.1`) — log collector that discovers Docker containers via the Docker socket, parses JSON logs from `book-share-api` (extracting `level` and `category` as indexed Loki labels and parsing timestamps from the payload), and forwards to Loki. Replaces the now-EOL Promtail. Runs as root (required for Docker socket access).
+**Alloy** (`grafana/alloy:v1.14.1`) — log collector that discovers Docker containers via the Docker socket, parses JSON logs from both services using service-aware `stage.match` blocks, and forwards to Loki. Replaces the now-EOL Promtail. Runs as root (required for Docker socket access).
 
 For a full diagram of containers, networks, and ports see `docs/network-diagram.md`.
 
@@ -53,14 +53,17 @@ grafana/
     dashboards/
       dashboard.yml         # Dashboard provider config
   dashboards/
-    bookshare-overview.json # Overview dashboard (health, request rate, latency, errors)
+    bookshare-overview.json # Overview dashboard (health, request rate, latency, errors, cover detection stage latency)
     bookshare-logs.json     # Log exploration dashboard (log volume, level/category filters, API error rate, per-service logs)
 ```
 
 ### Log Label Conventions
 
-All containers get `service` and `container` labels from Alloy's relabel rules. `book-share-api` additionally gets `level` (mapped from `LogLevel`, e.g. `Information`, `Warning`, `Error`) and `category` (mapped from `Category`, e.g. `Services.ShareService`, `Hubs.ChatHub`) as indexed labels, parsed from its JSON log output. Cover-detection logs are forwarded as plain text with no additional labels.
+All containers get `service` and `container` labels from Alloy's relabel rules. Both services additionally get `level` and `category` as indexed labels, parsed from their JSON log output via service-aware `stage.match` blocks in `alloy/config.alloy`:
+
+- **book-share-api**: `LogLevel` → `level` (e.g. `Information`, `Warning`, `Error`), `Category` → `category` (e.g. `Services.ShareService`, `Hubs.ChatHub`)
+- **cover-detection**: `level` → `level` (e.g. `INFO`, `ERROR`), `logger_name` → `category` (e.g. `app.services.analyzer`, `app.engines.florence2_onnx_engine`)
 
 ### Metric Name Conventions
 
-The API uses OpenTelemetry metric names (`http_server_request_duration_seconds_*`). Cover-detection uses prometheus-fastapi-instrumentator names (`http_request_duration_seconds_*`). Dashboard queries account for both naming schemes.
+The API uses OpenTelemetry metric names (`http_server_request_duration_seconds_*`). Cover-detection uses prometheus-fastapi-instrumentator names (`http_request_duration_seconds_*`). Cover-detection also exposes custom stage histograms: `cover_detection_ocr_duration_seconds`, `cover_detection_nlp_duration_seconds`, and `cover_detection_total_duration_seconds`. Dashboard queries account for all of these naming schemes.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See [`docs/network-diagram.md`](docs/network-diagram.md) for a diagram of how co
    - **Prometheus**: http://localhost:9090
 
 Grafana is provisioned with two dashboards under the **BookShare** folder:
-- **BookShare Overview** — service health, request rate, latency, and error rate (Prometheus)
+- **BookShare Overview** — service health, request rate, latency, error rate, and cover detection stage latency (Prometheus)
 - **BookShare Logs** — log volume, per-service log explorer with level/category filters, and API error rate (Loki)
 
 Scrape targets and log sources will show as down until the monitored services are running on the `booksharing` network.
@@ -80,13 +80,20 @@ docker compose restart prometheus
 
 ## Logs
 
-Alloy automatically discovers and collects logs from all Docker containers on the host. For `book-share-api`, Alloy parses the JSON log output and promotes `level` and `category` as indexed Loki labels. Logs are queryable in Grafana using [LogQL](https://grafana.com/docs/loki/latest/query/) via the Loki datasource.
+Alloy automatically discovers and collects logs from all Docker containers on the host. Both `book-share-api` and `cover-detection` emit structured JSON logs, and Alloy parses each with service-aware field mappings to promote `level` and `category` as indexed Loki labels:
+
+- **book-share-api**: maps `LogLevel` → `level`, `Category` → `category`
+- **cover-detection**: maps `level` → `level`, `logger_name` → `category`
+
+Logs are queryable in Grafana using [LogQL](https://grafana.com/docs/loki/latest/query/) via the Loki datasource.
 
 Useful label filters:
 - `{service="book-share-api"}` — API logs
 - `{service="book-share-api", level="Error"}` — API errors only
 - `{service="book-share-api", category="Services.ShareService"}` — logs from a specific category
 - `{service="cover-detection"}` — cover detection logs
+- `{service="cover-detection", level="ERROR"}` — cover detection errors only
+- `{service="cover-detection", category="app.services.analyzer"}` — logs from a specific logger
 - `{container="<name>"}` — logs for any specific container by its Docker name
 
-The `| json` pipeline operator enables ad-hoc extraction of structured fields from API log lines (e.g. `ShareId`, `UserId`, `RequestId`).
+The `| json` pipeline operator enables ad-hoc extraction of structured fields from log lines (e.g. `ShareId`, `UserId`, `RequestId` from API logs).

--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -35,25 +35,54 @@ loki.source.docker "containers" {
 loki.process "json_parse" {
   forward_to = [loki.write.loki.receiver]
 
-  stage.json {
-    expressions = {
-      level     = "LogLevel",
-      category  = "Category",
-      message   = "Message",
-      timestamp = "Timestamp",
+  stage.match {
+    selector = "{service=\"book-share-api\"}"
+
+    stage.json {
+      expressions = {
+        level     = "LogLevel",
+        category  = "Category",
+        message   = "Message",
+        timestamp = "Timestamp",
+      }
+    }
+
+    stage.labels {
+      values = {
+        level    = "",
+        category = "",
+      }
+    }
+
+    stage.timestamp {
+      source = "timestamp"
+      format = "2006-01-02T15:04:05.000Z"
     }
   }
 
-  stage.labels {
-    values = {
-      level    = "",
-      category = "",
-    }
-  }
+  stage.match {
+    selector = "{service=\"cover-detection\"}"
 
-  stage.timestamp {
-    source = "timestamp"
-    format = "2006-01-02T15:04:05.000Z"
+    stage.json {
+      expressions = {
+        level     = "level",
+        category  = "logger_name",
+        message   = "message",
+        timestamp = "timestamp",
+      }
+    }
+
+    stage.labels {
+      values = {
+        level    = "",
+        category = "",
+      }
+    }
+
+    stage.timestamp {
+      source = "timestamp"
+      format = "2006-01-02T15:04:05.000Z"
+    }
   }
 }
 

--- a/grafana/dashboards/bookshare-logs.json
+++ b/grafana/dashboards/bookshare-logs.json
@@ -93,7 +93,7 @@
       "datasource": { "type": "loki", "uid": "loki" },
       "targets": [
         {
-          "expr": "{service=\"cover-detection\"}",
+          "expr": "{service=\"cover-detection\", level=~\"$level\", category=~\"$cover_category\"} | json",
           "refId": "A"
         }
       ],
@@ -146,6 +146,23 @@
         "regex": "",
         "sort": 1,
         "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": { "type": "loki", "uid": "loki" },
+        "definition": "label_values({service=\"cover-detection\"}, category)",
+        "hide": 0,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "name": "cover_category",
+        "label": "Cover Logger",
+        "options": [],
+        "query": "label_values({service=\"cover-detection\"}, category)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
       }
     ]
   },
@@ -157,5 +174,5 @@
   "timezone": "browser",
   "title": "BookShare Logs",
   "uid": "bookshare-logs",
-  "version": 2
+  "version": 3
 }

--- a/grafana/dashboards/bookshare-overview.json
+++ b/grafana/dashboards/bookshare-overview.json
@@ -93,17 +93,17 @@
       "datasource": { "type": "prometheus", "name": "Prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum(rate(http_server_request_duration_seconds_bucket{http_route!~\"/metrics|/health\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(http_server_request_duration_seconds_bucket{http_route!~\"/metrics|/health|/books/analyze/cover\"}[5m])) by (le))",
           "legendFormat": "API p50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{http_route!~\"/metrics|/health\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{http_route!~\"/metrics|/health|/books/analyze/cover\"}[5m])) by (le))",
           "legendFormat": "API p95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket{http_route!~\"/metrics|/health\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket{http_route!~\"/metrics|/health|/books/analyze/cover\"}[5m])) by (le))",
           "legendFormat": "API p99",
           "refId": "C"
         },
@@ -177,6 +177,47 @@
         "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
         "tooltip": { "mode": "multi" }
       }
+    },
+    {
+      "id": 5,
+      "title": "Cover Detection Stage Latency",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 30 },
+      "datasource": { "type": "prometheus", "name": "Prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(cover_detection_ocr_duration_seconds_bucket[5m]))",
+          "legendFormat": "OCR p95",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(cover_detection_nlp_duration_seconds_bucket[5m]))",
+          "legendFormat": "NLP p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(cover_detection_total_duration_seconds_bucket[5m]))",
+          "legendFormat": "Total p95",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      }
     }
   ],
   "schemaVersion": 39,
@@ -187,5 +228,5 @@
   "timezone": "browser",
   "title": "BookShare Overview",
   "uid": "bookshare-overview",
-  "version": 1
+  "version": 3
 }


### PR DESCRIPTION
## Summary

- **Alloy**: replaced single `json_parse` pipeline with service-aware `stage.match` blocks — `book-share-api` continues using `.NET` field names (`LogLevel`, `Category`, `Timestamp`), while `cover-detection` now maps its Python field names (`level`, `logger_name`, `timestamp`) to the same indexed Loki labels
- **Logs dashboard**: cover-detection panel now filters by `$level` and a new `$cover_category` (Cover Logger) template variable, matching the filtering UX already in place for book-share-api
- **Overview dashboard**: new "Cover Detection Stage Latency" panel showing OCR/NLP/Total p95 from custom histograms; `/books/analyze/cover` excluded from general API latency panels to prevent it dominating the graph

Closes #11

> **Dependency**: requires the structured JSON logging changes from book-share-cover-detection#43 to be running before the Alloy parsing and dashboard filters produce data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)