### PR TITLE
Add Unresolved Reports stat panel to overview dashboard

### DIFF
--- a/grafana/dashboards/bookshare-overview.json
+++ b/grafana/dashboards/bookshare-overview.json
@@ -12,7 +12,7 @@
       "id": 1,
       "title": "Service Health",
       "type": "stat",
-      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 0 },
+      "gridPos": { "h": 6, "w": 18, "x": 0, "y": 0 },
       "datasource": { "type": "prometheus", "name": "Prometheus" },
       "targets": [
         {
@@ -31,6 +31,45 @@
             "steps": [
               { "color": "red", "value": null },
               { "color": "green", "value": 1 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Unresolved Reports",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 0 },
+      "datasource": { "type": "prometheus", "name": "Prometheus" },
+      "targets": [
+        {
+          "expr": "bookshare_reports_unresolved",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
             ]
           },
           "color": { "mode": "thresholds" }


### PR DESCRIPTION
## Summary

- Adds an **Unresolved Reports** Stat panel to the BookShare Overview dashboard, querying `bookshare_reports_unresolved`
- Panel displays green when count = 0, red when count ≥ 1 (background color mode)
- Resizes the existing Service Health panel from `w:24` to `w:18` to fit both on the same row

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)